### PR TITLE
chore(types): ensure exports is defined

### DIFF
--- a/src/plugins/unplugin.ts
+++ b/src/plugins/unplugin.ts
@@ -38,7 +38,7 @@ export const WorkerTransformPlugin = (opts: WorkerPluginOptions) => createUnplug
       const exports = opts.context.reverseMap[id]
       s.append([
         '',
-        `const __worker_exports__ = { ${exports.map(e => `${e}: ${e}`).join(', ')} }`,
+        `const __worker_exports__ = { ${exports!.map(e => `${e}: ${e}`).join(', ')} }`,
         `self.onmessage = async (e) => {`,
         `  const { name, args, id } = e.data`,
         `  const fn = __worker_exports__[name]`,


### PR DESCRIPTION
Actually here exports is throwing a type error during map because its type is either array of strings or undefined. That is why I've asserted it as it is defined.